### PR TITLE
Enabling onTap for TextSpans without a detection

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.2"
   fake_async:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/lib/functions.dart
+++ b/lib/functions.dart
@@ -47,6 +47,7 @@ TextSpan getDetectedTextSpan({
   required TextStyle basicStyle,
   required String source,
   required RegExp detectionRegExp,
+  bool alwaysDetectTap = false,
   Function(String)? onTap,
   bool decorateAtSign = false,
 }) {
@@ -66,7 +67,7 @@ TextSpan getDetectedTextSpan({
             final recognizer = TapGestureRecognizer()
               ..onTap = () {
                 final decoration = detections[index];
-                if (decoration.style == decoratedStyle) {
+                if (decoration.style == decoratedStyle || alwaysDetectTap) {
                   onTap!(decoration.range.textInside(source).trim());
                 }
               };

--- a/lib/widgets/detectable_text.dart
+++ b/lib/widgets/detectable_text.dart
@@ -13,6 +13,7 @@ class DetectableText extends StatelessWidget {
     this.basicStyle,
     this.detectedStyle,
     this.onTap,
+    this.alwaysDetectTap = false,
     this.textAlign = TextAlign.start,
     this.textDirection,
     this.softWrap = true,
@@ -29,6 +30,7 @@ class DetectableText extends StatelessWidget {
   final TextStyle? basicStyle;
   final TextStyle? detectedStyle;
   final Function(String)? onTap;
+  final bool alwaysDetectTap;
   final TextAlign textAlign;
   final TextDirection? textDirection;
   final bool softWrap;
@@ -51,6 +53,7 @@ class DetectableText extends StatelessWidget {
         decoratedStyle: dStyle,
         basicStyle: style,
         onTap: onTap,
+        alwaysDetectTap: alwaysDetectTap,
         source: text,
         detectionRegExp: detectionRegExp,
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
I added a boolean to the DetectableText widget's constructor called alwaysDetectTap. 

Before this, if a DetectableText had at least one detection, only the detections would respond to taps. If you tapped anywhere else on the text, nothing happened.

This is useful in an app like Twitter where posts can contain hashtags. If you tap on the hashtag you should go to a search screen. If you tap anywhere else on the Tweet, including the text that is not included in the hashtag, you should route to the Tweet.