### PR TITLE
Added Ability to reduce RegExp to initial match

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.2"
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:

--- a/lib/detector/detector.dart
+++ b/lib/detector/detector.dart
@@ -21,11 +21,13 @@ class Detector {
   final TextStyle textStyle;
   final TextStyle detectedStyle;
   final RegExp detectionRegExp;
+  final bool matchFirst;
 
   Detector({
     required this.textStyle,
     required this.detectedStyle,
     required this.detectionRegExp,
+    this.matchFirst = false,
   });
 
   List<Detection> _getSourceDetections(
@@ -120,9 +122,14 @@ class Detector {
           emojiMatch.start, emojiMatch.end, replacementText);
     });
 
-    final tags = detectionRegExp.allMatches(copiedText).toList();
+    List<RegExpMatch> tags = detectionRegExp.allMatches(copiedText).toList();
     if (tags.isEmpty) {
       return [];
+    }
+
+    if(matchFirst){
+      //Reduce down to the first match
+      tags = [tags[0]];
     }
 
     final sourceDetections = _getSourceDetections(tags, copiedText);

--- a/lib/widgets/detectable_editable_text.dart
+++ b/lib/widgets/detectable_editable_text.dart
@@ -23,6 +23,7 @@ class DetectableEditableText extends EditableText {
     required Color cursorColor,
     required this.onDetectionTyped,
     required this.onDetectionFinished,
+    required this.matchFirst,
     ValueChanged<String>? onChanged,
     ValueChanged<String>? onSubmitted,
     int? maxLines,
@@ -148,6 +149,8 @@ class DetectableEditableText extends EditableText {
 
   final VoidCallback? onDetectionFinished;
 
+  final bool matchFirst;
+
   @override
   DetectableEditableTextState createState() => DetectableEditableTextState();
 }
@@ -170,6 +173,7 @@ class DetectableEditableTextState extends EditableTextState {
       textStyle: widget.style,
       detectedStyle: widget.detectedStyle,
       detectionRegExp: widget.detectionRegExp,
+      matchFirst: widget.matchFirst,
     );
     widget.controller.addListener(() {
       _onValueUpdated.call();

--- a/lib/widgets/detectable_text_field.dart
+++ b/lib/widgets/detectable_text_field.dart
@@ -333,6 +333,7 @@ class DetectableTextField extends StatefulWidget {
     this.basicStyle,
     this.controller,
     this.focusNode,
+    this.matchFirst = false,
     this.decoration = const InputDecoration(),
     TextInputType? keyboardType,
     this.textInputAction,
@@ -438,6 +439,8 @@ class DetectableTextField extends StatefulWidget {
   final TextStyle? decoratedStyle;
 
   final RegExp detectionRegExp;
+
+  final bool matchFirst;
 
   /// Controls the text being edited.
   ///
@@ -1280,6 +1283,7 @@ class _DetectableTextFieldState extends State<DetectableTextField>
         child: DetectableEditableText(
           key: editableTextKey,
           detectionRegExp: widget.detectionRegExp,
+          matchFirst: widget.matchFirst,
           detectedStyle:
               widget.decoratedStyle ?? style.copyWith(color: Colors.blue),
           onDetectionFinished: widget.onDetectionFinished,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Changelog:
-
- Added `matchFirst` variable to the `Detector` as a conditional variable with is defaulted to `false`.
  - When set to `true` it reduces the RegExp match list to the first match
- Passed this variable in through the `TextField` and `EdittableText`