### PR TITLE
non-decorated text spans should not absorb onTap events

### DIFF
--- a/lib/composer/composer.dart
+++ b/lib/composer/composer.dart
@@ -81,7 +81,7 @@ class Composer {
         }
       },
     ).toList();
-    return TextSpan(children: span);
+    return TextSpan(children: span, style: detectedStyle);
   }
 
   Detection? typingDetection() {

--- a/lib/functions.dart
+++ b/lib/functions.dart
@@ -47,7 +47,6 @@ TextSpan getDetectedTextSpan({
   required TextStyle basicStyle,
   required String source,
   required RegExp detectionRegExp,
-  bool alwaysDetectTap = false,
   Function(String)? onTap,
   bool decorateAtSign = false,
 }) {
@@ -64,13 +63,14 @@ TextSpan getDetectedTextSpan({
         .asMap()
         .map(
           (index, item) {
-            final recognizer = TapGestureRecognizer()
-              ..onTap = () {
-                final decoration = detections[index];
-                if (decoration.style == decoratedStyle || alwaysDetectTap) {
-                  onTap!(decoration.range.textInside(source).trim());
-                }
-              };
+            TapGestureRecognizer? recognizer;
+            final decoration = detections[index];
+            if (decoration.style == decoratedStyle && onTap != null) {
+              recognizer = TapGestureRecognizer()
+                ..onTap = () {
+                  onTap(decoration.range.textInside(source).trim());
+                };
+            }
             return MapEntry(
               index,
               TextSpan(
@@ -95,7 +95,6 @@ TextSpan getDetectedTextSpanWithExtraChild(
     required RegExp detectionRegExp,
     Function(String)? onTap,
     bool decorateAtSign = false,
-      bool alwaysDetectTap = false,
     List<InlineSpan>? children}) {
   final detections = Detector(
     detectedStyle: decoratedStyle,
@@ -115,13 +114,14 @@ TextSpan getDetectedTextSpanWithExtraChild(
         .asMap()
         .map(
           (index, item) {
-            final recognizer = TapGestureRecognizer()
-              ..onTap = () {
-                final decoration = detections[index];
-                if (decoration.style == decoratedStyle || alwaysDetectTap) {
-                  onTap!(decoration.range.textInside(source).trim());
-                }
-              };
+            TapGestureRecognizer? recognizer;
+            final decoration = detections[index];
+            if (decoration.style == decoratedStyle && onTap != null) {
+              recognizer = TapGestureRecognizer()
+                ..onTap = () {
+                  onTap(decoration.range.textInside(source).trim());
+                };
+            }
             return MapEntry(
               index,
               TextSpan(

--- a/lib/widgets/detectable_text.dart
+++ b/lib/widgets/detectable_text.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 
 import '../functions.dart';
 
-
 enum TrimMode {
   Length,
   Line,
@@ -16,14 +15,12 @@ const String _kLineSeparator = '\u2028';
 ///
 /// [onTap] is called when a tagged text is tapped.
 class DetectableText extends StatefulWidget {
-
   DetectableText({
     required this.text,
     required this.detectionRegExp,
     this.basicStyle,
     this.detectedStyle,
     this.onTap,
-    this.alwaysDetectTap = false,
     this.textAlign = TextAlign.start,
     this.textDirection,
     this.softWrap = true,
@@ -50,7 +47,6 @@ class DetectableText extends StatefulWidget {
   final TextStyle? basicStyle;
   final TextStyle? detectedStyle;
   final Function(String)? onTap;
-  final bool alwaysDetectTap;
   final TextAlign textAlign;
   final TextDirection? textDirection;
   final bool softWrap;
@@ -63,6 +59,7 @@ class DetectableText extends StatefulWidget {
   final TextHeightBehavior? textHeightBehavior;
   final RegExp detectionRegExp;
   final String delimiter;
+
   /// Used on TrimMode.Length
   final int trimLength;
 
@@ -123,8 +120,8 @@ class _DetectableTextState extends State<DetectableText> {
     TextSpan _delimiter = TextSpan(
       text: _readMore
           ? widget.trimCollapsedText.isNotEmpty
-          ? widget.delimiter
-          : ''
+              ? widget.delimiter
+              : ''
           : '',
       style: _defaultDelimiterStyle,
       recognizer: TapGestureRecognizer()..onTap = _onTapLink,
@@ -142,7 +139,6 @@ class _DetectableTextState extends State<DetectableText> {
           onTap: widget.onTap,
           source: widget.text,
           detectionRegExp: widget.detectionRegExp,
-          alwaysDetectTap: widget.alwaysDetectTap,
         );
 
         // Layout and measure link
@@ -201,25 +197,23 @@ class _DetectableTextState extends State<DetectableText> {
               //   children: <TextSpan>[_delimiter, link],
               // );
 
-              textSpan =  getDetectedTextSpanWithExtraChild(
+              textSpan = getDetectedTextSpanWithExtraChild(
                 decoratedStyle: dStyle,
                 basicStyle: style,
                 onTap: widget.onTap,
-                alwaysDetectTap: widget.alwaysDetectTap,
                 source: _readMore
                     ? widget.text.substring(0, widget.trimLength) +
-                    (linkLongerThanLine ? _kLineSeparator : '')
+                        (linkLongerThanLine ? _kLineSeparator : '')
                     : widget.text,
                 detectionRegExp: widget.detectionRegExp,
                 children: <TextSpan>[_delimiter, link],
               );
             } else {
-              textSpan =  getDetectedTextSpan(
+              textSpan = getDetectedTextSpan(
                 decoratedStyle: dStyle,
                 basicStyle: style,
                 onTap: widget.onTap,
                 source: widget.text,
-                alwaysDetectTap: widget.alwaysDetectTap,
                 detectionRegExp: widget.detectionRegExp,
               );
             }
@@ -235,19 +229,19 @@ class _DetectableTextState extends State<DetectableText> {
               //   children: <TextSpan>[_delimiter, link],
               // );
 
-              textSpan =  getDetectedTextSpanWithExtraChild(
+              textSpan = getDetectedTextSpanWithExtraChild(
                 decoratedStyle: dStyle,
                 basicStyle: style,
                 onTap: widget.onTap,
                 source: _readMore
                     ? widget.text.substring(0, endIndex) +
-                    (linkLongerThanLine ? _kLineSeparator : '')
+                        (linkLongerThanLine ? _kLineSeparator : '')
                     : widget.text,
                 detectionRegExp: widget.detectionRegExp,
                 children: <TextSpan>[_delimiter, link],
               );
             } else {
-              textSpan =  getDetectedTextSpan(
+              textSpan = getDetectedTextSpan(
                 decoratedStyle: dStyle,
                 basicStyle: style,
                 onTap: widget.onTap,


### PR DESCRIPTION
Background: 
when I was using your fancy detectable text widget, everything went well except that normal text spans inside a DetectableText widget will absorb onTap events of its parent. 

But actually normal text span should not contain any recognizer, as it will override any onTap callback of its parent. A conventional behavior should be: its parent as a GestureDetector opens up a HitTestBehavior.opaque behavior and an onTap handler to handle logics with a higher priority. Decorated text spans inside the DetectableText widget will override its parent's onTap.

Thanks,

Xiaowei