### PR TITLE
Fixed to recognize domains with only one character

### DIFF
--- a/lib/detector/sample_regular_expressions.dart
+++ b/lib/detector/sample_regular_expressions.dart
@@ -29,7 +29,7 @@ const detectionContentLetters = _symbols +
 
 const urlRegexContent = "((http|https)://)?(www.)?" +
     "[-a-zA-Z0-9@:%._\\+~#?&//=]" +
-    "{2,256}\\.[a-z]" +
+    "{1,256}\\.[a-z]" +
     "{2,6}\\b([-a-zA-Z0-9@:%" +
     "._\\+~#?&//=]*)";
 


### PR DESCRIPTION
Fixed this issue.
- https://github.com/santa112358/detectable_text_field/issues/49#issue-1861710140